### PR TITLE
Optimize workflow to upload artifact once

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: tar -cf public.tar ./public
-      - uses: actions/upload-artifact@v4.4.3
+      - uses: actions/upload-pages-artifact@v3.0.1
         with:
-          name: public.tar
-          path: public.tar
+          path: public
 
   publish:
     if: github.ref == 'refs/heads/master'
@@ -46,14 +45,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4.1.8
-        with:
-          name: public.tar
-      - run: tar -xf public.tar
       - uses: actions/configure-pages@v5.0.0
-      - uses: actions/upload-pages-artifact@v3.0.1
-        with:
-          path: public
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4.0.5


### PR DESCRIPTION
Update the workflow to directly upload the `public` directory in the `build` job and remove unnecessary steps in the `publish` job.

* **Build Job:**
  - Replace `actions/upload-artifact@v4.4.3` with `actions/upload-pages-artifact@v3.0.1`.
  - Change the path to `public` instead of `public.tar`.

* **Publish Job:**
  - Remove `actions/download-artifact@v4.1.8` step.
  - Remove the step to extract `public.tar`.
  - Remove `actions/upload-pages-artifact@v3.0.1` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/uk-x-gov-software-community/xgov-opensource-repo-scraper?shareId=5a3cea4c-b682-4c35-a99f-6124ffd9c5d3).