### PR TITLE
revert: restore upstream governments.yml URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ async function getOrgs() {
   const allDepartments = yaml.safeLoad(
     await (
       await fetch(
-        "https://raw.githubusercontent.com/chrisns/government.github.com/add-uk-public-sector-orgs-202602/_data/governments.yml"
+        "https://raw.githubusercontent.com/github/government.github.com/gh-pages/_data/governments.yml"
       )
     ).text()
   );


### PR DESCRIPTION
## ⛔ DO NOT MERGE until upstream PR lands

This PR reverts the temporary fork URL back to the canonical `github/government.github.com` source.

### When to merge

Merge this PR **only after** [github/government.github.com#1322](https://github.com/github/government.github.com/pull/1322) has been merged upstream. Until then, the fork URL is needed to include ~80 new UK public sector orgs.

### What this does

- Restores `governments.yml` fetch URL from `chrisns/government.github.com@add-uk-public-sector-orgs-202602` back to `github/government.github.com@gh-pages`
- Reverts the change made in #25