### PR TITLE
perf: GraphQL API + fan-out CI for faster builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,16 @@ jobs:
           node-version-file: '.nvm'
       - run: npm install
       - run: npm test
+      - name: Restore repo cache
+        uses: actions/cache@v4
+        with:
+          path: cache/
+          key: repo-cache-${{ github.run_id }}
+          restore-keys: |
+            repo-cache-
       - run: |
           for i in {1..3}; do
-            node index.js get-all -w ./public/repos.json && break
+            node index.js get-all -w ./public/repos.json --cache-dir ./cache && break
             if [ $i -eq 3 ]; then exit 1; fi
           done
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    permissions:
-      contents: read
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -25,20 +23,53 @@ jobs:
           node-version-file: '.nvm'
       - run: npm install
       - run: npm test
+
+  scrape:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: [0, 1, 2]
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4.1.0
+        with:
+          node-version-file: '.nvm'
+      - run: npm install
       - name: Restore repo cache
         uses: actions/cache@v4
         with:
           path: cache/
-          key: repo-cache-${{ github.run_id }}
+          key: repo-cache-chunk${{ matrix.chunk }}-${{ github.run_id }}
           restore-keys: |
-            repo-cache-
+            repo-cache-chunk${{ matrix.chunk }}-
       - run: |
           for i in {1..3}; do
-            node index.js get-all -w ./public/repos.json --cache-dir ./cache && break
+            node index.js get-all -w ./chunk-${{ matrix.chunk }}.json --cache-dir ./cache --chunk ${{ matrix.chunk }} --total-chunks 3 && break
             if [ $i -eq 3 ]; then exit 1; fi
           done
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v4.4.3
+        with:
+          name: chunk-${{ matrix.chunk }}
+          path: chunk-${{ matrix.chunk }}.json
+
+  build:
+    needs: scrape
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4.1.0
+        with:
+          node-version-file: '.nvm'
+      - run: npm install
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          pattern: chunk-*
+          merge-multiple: true
+      - run: node index.js merge-chunks chunk-0.json chunk-1.json chunk-2.json -w ./public/repos.json
       - run: tar -cf public.tar ./public
       - uses: actions/upload-artifact@v4.4.3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        chunk: [0, 1, 2]
+        chunk: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-node@v4.1.0
@@ -46,7 +46,7 @@ jobs:
             repo-cache-chunk${{ matrix.chunk }}-
       - run: |
           for i in {1..3}; do
-            node index.js get-all -w ./chunk-${{ matrix.chunk }}.json --cache-dir ./cache --chunk ${{ matrix.chunk }} --total-chunks 3 && break
+            node index.js get-all -w ./chunk-${{ matrix.chunk }}.json --cache-dir ./cache --chunk ${{ matrix.chunk }} --total-chunks 4 && break
             if [ $i -eq 3 ]; then exit 1; fi
           done
         env:
@@ -69,7 +69,7 @@ jobs:
         with:
           pattern: chunk-*
           merge-multiple: true
-      - run: node index.js merge-chunks chunk-0.json chunk-1.json chunk-2.json -w ./public/repos.json
+      - run: node index.js merge-chunks chunk-0.json chunk-1.json chunk-2.json chunk-3.json -w ./public/repos.json
       - run: tar -cf public.tar ./public
       - uses: actions/upload-artifact@v4.4.3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,8 @@ jobs:
       - uses: actions/setup-node@v4.1.0
         with:
           node-version-file: '.nvm'
-      - run: npm install
+          cache: 'npm'
+      - run: npm ci
       - run: npm test
 
   scrape:
@@ -36,7 +37,8 @@ jobs:
       - uses: actions/setup-node@v4.1.0
         with:
           node-version-file: '.nvm'
-      - run: npm install
+          cache: 'npm'
+      - run: npm ci --omit=dev
       - name: Restore repo cache
         uses: actions/cache@v4
         with:
@@ -61,15 +63,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-node@v4.1.0
-        with:
-          node-version-file: '.nvm'
-      - run: npm install
       - uses: actions/download-artifact@v4.1.8
         with:
           pattern: chunk-*
           merge-multiple: true
-      - run: node index.js merge-chunks chunk-0.json chunk-1.json chunk-2.json chunk-3.json -w ./public/repos.json
+      - name: Merge chunks
+        run: |
+          node -e "
+          const fs = require('fs');
+          const chunks = [0,1,2,3].map(i => JSON.parse(fs.readFileSync('chunk-'+i+'.json','utf8')));
+          const all = chunks.flat();
+          fs.writeFileSync('./public/repos.json', JSON.stringify(all, null, 2));
+          console.log('Merged ' + chunks.length + ' chunks: ' + all.length + ' repos');
+          "
       - run: tar -cf public.tar ./public
       - uses: actions/upload-artifact@v4.4.3
         with:

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const GRAPHQL_URL = "https://api.github.com/graphql";
 const BATCH_SIZE = 3; // orgs per GraphQL query (tested max with issues sub-connection)
 const CONCURRENCY = 1; // sequential requests to avoid secondary rate limits
 const CHANGE_DETECT_BATCH = 50; // orgs per change detection query (no issues = higher limit)
-const INTER_BATCH_DELAY_MS = 2000; // delay between batches (safe for 3 parallel CI jobs sharing a token)
+const INTER_BATCH_DELAY_MS = 3000; // delay between batches (avoids secondary rate limits with 3 parallel CI jobs)
 const MAX_RETRIES = 5;
 
 async function getOrgs() {

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const program = new Command();
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
 const GRAPHQL_URL = "https://api.github.com/graphql";
 const BATCH_SIZE = 3; // orgs per GraphQL query (tested max with issues sub-connection)
-const CONCURRENCY = 2; // concurrent GraphQL requests (low to avoid secondary rate limits)
+const CONCURRENCY = 1; // sequential requests to avoid secondary rate limits
 const CHANGE_DETECT_BATCH = 50; // orgs per change detection query (no issues = higher limit)
-const INTER_BATCH_DELAY_MS = 2000; // delay between concurrent batches to avoid secondary rate limits
+const INTER_BATCH_DELAY_MS = 2000; // delay between batches (safe for 3 parallel CI jobs sharing a token)
 const MAX_RETRIES = 5;
 
 async function getOrgs() {
@@ -405,12 +405,37 @@ program
   .command("get-all")
   .option("-w, --write <outputfile>", "Save output to a file")
   .option("--cache-dir <dir>", "Directory for caching org data between runs")
+  .option("--chunk <n>", "Chunk index (0-based) for parallel fan-out", parseInt)
+  .option("--total-chunks <n>", "Total number of chunks for parallel fan-out", parseInt)
   .description(
     "Get consolidated data for all UK Government departments and agencies"
   )
   .action(async (options) => {
-    const orgs = await getOrgs();
+    let orgs = await getOrgs();
+    if (options.totalChunks > 1 && options.chunk !== undefined) {
+      const chunkSize = Math.ceil(orgs.length / options.totalChunks);
+      const start = options.chunk * chunkSize;
+      orgs = orgs.slice(start, start + chunkSize);
+      console.log(
+        `Chunk ${options.chunk + 1}/${options.totalChunks}: processing ${orgs.length} orgs (index ${start}-${start + orgs.length - 1})`
+      );
+    }
     const allRepos = await fetchAllRepos(orgs, options.cacheDir);
+    return outputIt(allRepos, options.write);
+  });
+
+program
+  .command("merge-chunks")
+  .description("Merge chunk JSON files into a single output")
+  .option("-w, --write <outputfile>", "Save merged output to a file")
+  .argument("<files...>", "Chunk JSON files to merge")
+  .action(async (files, options) => {
+    const allRepos = [];
+    for (const file of files) {
+      const data = JSON.parse(readFileSync(file, "utf8"));
+      allRepos.push(...data);
+    }
+    console.log(`Merged ${files.length} chunks: ${allRepos.length} total repos`);
     return outputIt(allRepos, options.write);
   });
 

--- a/index.js
+++ b/index.js
@@ -8,11 +8,8 @@ const GRAPHQL_URL = "https://api.github.com/graphql";
 const BATCH_SIZE = 3; // orgs per GraphQL query (tested max with issues sub-connection)
 const CONCURRENCY = 1; // sequential requests to avoid secondary rate limits
 const CHANGE_DETECT_BATCH = 50; // orgs per change detection query (no issues = higher limit)
-const INITIAL_DELAY_MS = 500; // start fast, increase on rate limits
-const MAX_DELAY_MS = 5000;
+const INTER_BATCH_DELAY_MS = 2000; // delay between batches
 const MAX_RETRIES = 5;
-
-let batchDelayMs = INITIAL_DELAY_MS;
 
 async function getOrgs() {
   const allDepartments = yaml.load(
@@ -65,9 +62,8 @@ async function graphqlFetch(query) {
       const waitMs = retryAfter
         ? parseInt(retryAfter, 10) * 1000
         : Math.min(2000 * Math.pow(2, attempt), 120000);
-      batchDelayMs = Math.min(batchDelayMs * 2, MAX_DELAY_MS);
       console.log(
-        `Rate limit/server error (${resp.status}), retrying in ${Math.ceil(waitMs / 1000)}s, batch delay now ${batchDelayMs}ms (attempt ${attempt + 1}/${MAX_RETRIES})...`
+        `Rate limit/server error (${resp.status}), retrying in ${Math.ceil(waitMs / 1000)}s (attempt ${attempt + 1}/${MAX_RETRIES})...`
       );
       await delay(waitMs);
       continue;
@@ -180,7 +176,7 @@ async function detectChangedOrgs(orgs, cache) {
     );
 
     if (i + CONCURRENCY < batches.length) {
-      await delay(batchDelayMs);
+      await delay(INTER_BATCH_DELAY_MS);
     }
 
     for (let b = 0; b < results.length; b++) {
@@ -271,7 +267,7 @@ async function fetchAllRepos(orgs, cacheDir) {
       );
 
       if (i + CONCURRENCY < batches.length) {
-        await delay(batchDelayMs);
+        await delay(INTER_BATCH_DELAY_MS);
       }
 
       for (const outcome of results) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const GRAPHQL_URL = "https://api.github.com/graphql";
 const BATCH_SIZE = 3; // orgs per GraphQL query (tested max with issues sub-connection)
 const CONCURRENCY = 1; // sequential requests to avoid secondary rate limits
 const CHANGE_DETECT_BATCH = 50; // orgs per change detection query (no issues = higher limit)
-const INTER_BATCH_DELAY_MS = 3000; // delay between batches (avoids secondary rate limits with 3 parallel CI jobs)
+const INTER_BATCH_DELAY_MS = 2000; // delay between batches
 const MAX_RETRIES = 5;
 
 async function getOrgs() {

--- a/index.js
+++ b/index.js
@@ -8,8 +8,11 @@ const GRAPHQL_URL = "https://api.github.com/graphql";
 const BATCH_SIZE = 3; // orgs per GraphQL query (tested max with issues sub-connection)
 const CONCURRENCY = 1; // sequential requests to avoid secondary rate limits
 const CHANGE_DETECT_BATCH = 50; // orgs per change detection query (no issues = higher limit)
-const INTER_BATCH_DELAY_MS = 2000; // delay between batches
+const INITIAL_DELAY_MS = 500; // start fast, increase on rate limits
+const MAX_DELAY_MS = 5000;
 const MAX_RETRIES = 5;
+
+let batchDelayMs = INITIAL_DELAY_MS;
 
 async function getOrgs() {
   const allDepartments = yaml.load(
@@ -62,8 +65,9 @@ async function graphqlFetch(query) {
       const waitMs = retryAfter
         ? parseInt(retryAfter, 10) * 1000
         : Math.min(2000 * Math.pow(2, attempt), 120000);
+      batchDelayMs = Math.min(batchDelayMs * 2, MAX_DELAY_MS);
       console.log(
-        `Rate limit/server error (${resp.status}), retrying in ${Math.ceil(waitMs / 1000)}s (attempt ${attempt + 1}/${MAX_RETRIES})...`
+        `Rate limit/server error (${resp.status}), retrying in ${Math.ceil(waitMs / 1000)}s, batch delay now ${batchDelayMs}ms (attempt ${attempt + 1}/${MAX_RETRIES})...`
       );
       await delay(waitMs);
       continue;
@@ -176,7 +180,7 @@ async function detectChangedOrgs(orgs, cache) {
     );
 
     if (i + CONCURRENCY < batches.length) {
-      await delay(INTER_BATCH_DELAY_MS);
+      await delay(batchDelayMs);
     }
 
     for (let b = 0; b < results.length; b++) {
@@ -267,7 +271,7 @@ async function fetchAllRepos(orgs, cacheDir) {
       );
 
       if (i + CONCURRENCY < batches.length) {
-        await delay(INTER_BATCH_DELAY_MS);
+        await delay(batchDelayMs);
       }
 
       for (const outcome of results) {

--- a/index.js
+++ b/index.js
@@ -413,11 +413,10 @@ program
   .action(async (options) => {
     let orgs = await getOrgs();
     if (options.totalChunks > 1 && options.chunk !== undefined) {
-      const chunkSize = Math.ceil(orgs.length / options.totalChunks);
-      const start = options.chunk * chunkSize;
-      orgs = orgs.slice(start, start + chunkSize);
+      const total = orgs.length;
+      orgs = orgs.filter((_, i) => i % options.totalChunks === options.chunk);
       console.log(
-        `Chunk ${options.chunk + 1}/${options.totalChunks}: processing ${orgs.length} orgs (index ${start}-${start + orgs.length - 1})`
+        `Chunk ${options.chunk + 1}/${options.totalChunks}: processing ${orgs.length}/${total} orgs (round-robin)`
       );
     }
     const allRepos = await fetchAllRepos(orgs, options.cacheDir);

--- a/index.js
+++ b/index.js
@@ -1,22 +1,25 @@
-"use strict";
-
 import yaml from "js-yaml";
-import Octokat from "octokat";
-import Promise from "bluebird";
-import { writeFileSync } from "fs";
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from "fs";
 import { Command } from "commander";
 
 const program = new Command();
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+const GRAPHQL_URL = "https://api.github.com/graphql";
+const BATCH_SIZE = 3; // orgs per GraphQL query (tested max with issues sub-connection)
+const CONCURRENCY = 2; // concurrent GraphQL requests (low to avoid secondary rate limits)
+const CHANGE_DETECT_BATCH = 50; // orgs per change detection query (no issues = higher limit)
+const INTER_BATCH_DELAY_MS = 2000; // delay between concurrent batches to avoid secondary rate limits
+const MAX_RETRIES = 5;
 
 async function getOrgs() {
-  const allDepartments = yaml.safeLoad(
+  const allDepartments = yaml.load(
     await (
       await fetch(
         "https://raw.githubusercontent.com/chrisns/government.github.com/add-uk-public-sector-orgs-202602/_data/governments.yml"
       )
     ).text()
   );
-  const researchDepts = yaml.safeLoad(
+  const researchDepts = yaml.load(
     await (
       await fetch(
         "https://raw.githubusercontent.com/github/government.github.com/gh-pages/_data/research.yml"
@@ -30,15 +33,356 @@ async function getOrgs() {
   );
 }
 
-const octo = new Octokat({
-  token: process.env.GITHUB_TOKEN,
-});
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function graphqlFetch(query) {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    let resp;
+    try {
+      resp = await fetch(GRAPHQL_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `bearer ${GITHUB_TOKEN}`,
+          "Content-Type": "application/json",
+          "User-Agent": "xgov-opensource-repo-scraper",
+        },
+        body: JSON.stringify({ query }),
+      });
+    } catch (err) {
+      const waitMs = Math.min(2000 * Math.pow(2, attempt), 60000);
+      console.log(
+        `Network error (${err.message}), retrying in ${Math.ceil(waitMs / 1000)}s (attempt ${attempt + 1}/${MAX_RETRIES})...`
+      );
+      await delay(waitMs);
+      continue;
+    }
+
+    if (resp.status === 403 || resp.status === 429 || resp.status === 502) {
+      const retryAfter = resp.headers.get("retry-after");
+      const waitMs = retryAfter
+        ? parseInt(retryAfter, 10) * 1000
+        : Math.min(2000 * Math.pow(2, attempt), 120000);
+      console.log(
+        `Rate limit/server error (${resp.status}), retrying in ${Math.ceil(waitMs / 1000)}s (attempt ${attempt + 1}/${MAX_RETRIES})...`
+      );
+      await delay(waitMs);
+      continue;
+    }
+
+    if (!resp.ok) {
+      throw new Error(`GraphQL HTTP ${resp.status}: ${await resp.text()}`);
+    }
+
+    const json = await resp.json();
+    if (json.errors) {
+      const fatal = json.errors.filter((e) => e.type !== "NOT_FOUND");
+      if (fatal.length && !json.data) {
+        throw new Error(`GraphQL errors: ${JSON.stringify(fatal)}`);
+      }
+    }
+    return json;
+  }
+  throw new Error(`Failed after ${MAX_RETRIES} retries`);
+}
+
+function buildRepoQuery(entries) {
+  const fragments = entries.map(({ alias, login, cursor }) => {
+    const afterArg = cursor ? `, after: "${cursor}"` : "";
+    return `
+    ${alias}: repositoryOwner(login: "${login}") {
+      repositories(first: 100, orderBy: {field: UPDATED_AT, direction: DESC}${afterArg}) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          owner { login }
+          name
+          description
+          url
+          isArchived
+          licenseInfo { key name spdxId }
+          stargazerCount
+          primaryLanguage { name }
+          forkCount
+          issues(states: OPEN) { totalCount }
+          createdAt
+          updatedAt
+          pushedAt
+        }
+      }
+    }`;
+  });
+  return `{ rateLimit { cost remaining resetAt } ${fragments.join("\n")} }`;
+}
+
+function buildChangeDetectionQuery(orgs) {
+  const fragments = orgs.map((login, i) => {
+    return `
+    o${i}: repositoryOwner(login: "${login}") {
+      repositories(first: 1, orderBy: {field: PUSHED_AT, direction: DESC}) {
+        totalCount
+        nodes { pushedAt }
+      }
+    }`;
+  });
+  return `{ rateLimit { cost remaining resetAt } ${fragments.join("\n")} }`;
+}
+
+function formatRepo(node) {
+  if (!node) return null;
+  return {
+    owner: node.owner.login,
+    name: node.name,
+    description: node.description,
+    url: node.url,
+    archived: node.isArchived,
+    license: node.licenseInfo,
+    stargazersCount: node.stargazerCount,
+    language: node.primaryLanguage?.name ?? null,
+    forksCount: node.forkCount,
+    openIssuesCount: node.issues.totalCount,
+    createdAt: node.createdAt,
+    updatedAt: node.updatedAt,
+    pushedAt: node.pushedAt,
+  };
+}
+
+async function checkRateLimit(rateLimit) {
+  if (rateLimit && rateLimit.remaining < 50) {
+    const resetAt = new Date(rateLimit.resetAt);
+    const waitMs = resetAt - Date.now() + 1000;
+    if (waitMs > 0) {
+      console.log(
+        `Rate limit low (${rateLimit.remaining} remaining), waiting ${Math.ceil(waitMs / 1000)}s...`
+      );
+      await new Promise((r) => setTimeout(r, waitMs));
+    }
+  }
+}
+
+async function detectChangedOrgs(orgs, cache) {
+  if (!cache) return new Set(orgs);
+
+  console.log("Running change detection...");
+  const changed = new Set();
+  const batches = [];
+  for (let i = 0; i < orgs.length; i += CHANGE_DETECT_BATCH) {
+    batches.push(orgs.slice(i, i + CHANGE_DETECT_BATCH));
+  }
+
+  for (let i = 0; i < batches.length; i += CONCURRENCY) {
+    const concurrent = batches.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(
+      concurrent.map((batch) => graphqlFetch(buildChangeDetectionQuery(batch)))
+    );
+
+    if (i + CONCURRENCY < batches.length) {
+      await delay(INTER_BATCH_DELAY_MS);
+    }
+
+    for (let b = 0; b < results.length; b++) {
+      if (results[b].status === "rejected") {
+        concurrent[b].forEach((org) => changed.add(org));
+        continue;
+      }
+      const data = results[b].value.data;
+      await checkRateLimit(data?.rateLimit);
+
+      for (let j = 0; j < concurrent[b].length; j++) {
+        const org = concurrent[b][j];
+        const orgData = data?.[`o${j}`];
+        if (!orgData) {
+          changed.add(org);
+          continue;
+        }
+        const repos = orgData.repositories;
+        const latestPush = repos.nodes[0]?.pushedAt ?? null;
+        const cached = cache[org];
+        if (
+          !cached ||
+          cached.totalCount !== repos.totalCount ||
+          cached.latestPushedAt !== latestPush
+        ) {
+          changed.add(org);
+        }
+      }
+    }
+  }
+
+  console.log(
+    `Change detection: ${changed.size} orgs changed, ${orgs.length - changed.size} cached`
+  );
+  return changed;
+}
+
+async function fetchAllRepos(orgs, cacheDir) {
+  const startTime = Date.now();
+  let cache = null;
+
+  if (cacheDir && existsSync(`${cacheDir}/repos-by-org.json`)) {
+    try {
+      cache = JSON.parse(readFileSync(`${cacheDir}/repos-by-org.json`, "utf8"));
+      console.log(
+        `Loaded cache: ${Object.keys(cache).length} orgs cached`
+      );
+    } catch {
+      console.log("Cache file corrupt, fetching all orgs fresh");
+    }
+  }
+
+  const changedOrgs = await detectChangedOrgs(orgs, cache);
+  const orgsToFetch = orgs.filter((o) => changedOrgs.has(o));
+
+  console.log(
+    `Fetching ${orgsToFetch.length} orgs via GraphQL (batch=${BATCH_SIZE}, concurrency=${CONCURRENCY})`
+  );
+
+  const reposByOrg = cache ? { ...cache } : {};
+  let queue = orgsToFetch.map((login) => ({
+    login,
+    cursor: null,
+    alias: null,
+  }));
+  let totalQueries = 0;
+
+  while (queue.length > 0) {
+    const batches = [];
+    for (let i = 0; i < queue.length; i += BATCH_SIZE) {
+      const batch = queue.slice(i, i + BATCH_SIZE).map((item, j) => ({
+        ...item,
+        alias: `o${j}`,
+      }));
+      batches.push(batch);
+    }
+
+    const nextQueue = [];
+
+    for (let i = 0; i < batches.length; i += CONCURRENCY) {
+      const concurrent = batches.slice(i, i + CONCURRENCY);
+
+      const results = await Promise.allSettled(
+        concurrent.map(async (batch) => {
+          const query = buildRepoQuery(batch);
+          return { batch, result: await graphqlFetch(query) };
+        })
+      );
+
+      if (i + CONCURRENCY < batches.length) {
+        await delay(INTER_BATCH_DELAY_MS);
+      }
+
+      for (const outcome of results) {
+        if (outcome.status === "rejected") {
+          console.error("Query failed:", outcome.reason?.message);
+          continue;
+        }
+
+        const { batch, result } = outcome.value;
+        totalQueries++;
+        await checkRateLimit(result.data?.rateLimit);
+
+        for (const entry of batch) {
+          const orgData = result.data?.[entry.alias];
+          if (!orgData) continue;
+
+          const repos = orgData.repositories;
+          const validNodes = repos.nodes.filter((n) => n !== null);
+          const formatted = validNodes.map(formatRepo).filter(Boolean);
+
+          if (!reposByOrg[entry.login]) {
+            reposByOrg[entry.login] = {
+              totalCount: repos.totalCount,
+              latestPushedAt: null,
+              repos: [],
+            };
+          }
+
+          if (!entry.cursor) {
+            reposByOrg[entry.login].repos = formatted;
+            reposByOrg[entry.login].totalCount = repos.totalCount;
+          } else {
+            reposByOrg[entry.login].repos.push(...formatted);
+          }
+
+          if (repos.pageInfo.hasNextPage) {
+            nextQueue.push({
+              login: entry.login,
+              cursor: repos.pageInfo.endCursor,
+            });
+          } else {
+            const orgRepos = reposByOrg[entry.login].repos;
+            reposByOrg[entry.login].latestPushedAt =
+              orgRepos.length > 0
+                ? orgRepos.reduce(
+                    (max, r) =>
+                      r.pushedAt > max ? r.pushedAt : max,
+                    orgRepos[0].pushedAt
+                  )
+                : null;
+            console.log(
+              `  ${entry.login}: ${orgRepos.length} repos`
+            );
+          }
+        }
+      }
+    }
+
+    queue = nextQueue;
+    if (queue.length > 0) {
+      console.log(`  ...${queue.length} orgs need more pages`);
+    }
+  }
+
+  if (cacheDir) {
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      `${cacheDir}/repos-by-org.json`,
+      JSON.stringify(reposByOrg, null, 2)
+    );
+    console.log(`Cache saved to ${cacheDir}/repos-by-org.json`);
+  }
+
+  const allRepos = [];
+  for (const org of orgs) {
+    if (reposByOrg[org]) {
+      allRepos.push(...reposByOrg[org].repos);
+    }
+  }
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(
+    `Done in ${elapsed}s: ${allRepos.length} repos from ${orgs.length} orgs (${totalQueries} GraphQL queries)`
+  );
+
+  return allRepos;
+}
+
+async function getRepos(org) {
+  const repos = [];
+  let cursor = null;
+
+  do {
+    const query = buildRepoQuery([{ alias: "o0", login: org, cursor }]);
+    const result = await graphqlFetch(query);
+    const orgData = result.data?.o0;
+    if (!orgData) break;
+
+    const pageRepos = orgData.repositories;
+    const validNodes = pageRepos.nodes.filter((n) => n !== null);
+    repos.push(...validNodes.map(formatRepo).filter(Boolean));
+    cursor = pageRepos.pageInfo.hasNextPage
+      ? pageRepos.pageInfo.endCursor
+      : null;
+  } while (cursor);
+
+  return repos;
+}
 
 async function outputIt(data, outputFile) {
+  const json = JSON.stringify(await data, null, 2);
   if (outputFile) {
-    writeFileSync(outputFile, JSON.stringify(await data, null, 2));
+    writeFileSync(outputFile, json);
   } else {
-    process.stdout.write(JSON.stringify(await data, null, 2));
+    process.stdout.write(json);
   }
 }
 
@@ -60,63 +404,14 @@ program
 program
   .command("get-all")
   .option("-w, --write <outputfile>", "Save output to a file")
+  .option("--cache-dir <dir>", "Directory for caching org data between runs")
   .description(
-    "Get consolodated data for all UK Government departments and agencies"
+    "Get consolidated data for all UK Government departments and agencies"
   )
   .action(async (options) => {
     const orgs = await getOrgs();
-    let allRepos = [];
-    for (const org of orgs) {
-      const repos = await getRepos(org);
-      allRepos = allRepos.concat(repos);
-    }
+    const allRepos = await fetchAllRepos(orgs, options.cacheDir);
     return outputIt(allRepos, options.write);
   });
 
 program.parse();
-
-function formatRepoResult(result) {
-  return {
-    owner: result.owner.login,
-    name: result.name,
-    url: result.html.url,
-    archived: result.archived,
-    license: result.license,
-    stargazersCount: result.stargazersCount,
-    language: result.language,
-    forksCount: result.forksCount,
-    openIssuesCount: result.openIssuesCount,
-    createdAt: result.createdAt,
-    updatedAt: result.updatedAt,
-    pushedAt: result.pushedAt,
-  };
-}
-
-async function fetchAll(org) {
-  let aggregate = [];
-  try {
-    let response = await octo.orgs(org).repos.fetch({ per_page: 100 });
-    aggregate = [response];
-
-    console.log(`fetched page 1 for ${org}`);
-    let i = 1;
-    await Promise.delay(50);
-    while (response.nextPage) {
-      i++;
-      response = await response.nextPage();
-      console.log(`fetched page ${i} for ${org}`);
-      await Promise.delay(50);
-      aggregate.push(response);
-    }
-  } catch (error) {
-    console.error(error);
-    if (error.status != 404) {
-      throw error;
-    }
-  }
-  return aggregate;
-}
-
-async function getRepos(org) {
-  return (await fetchAll(org)).flat().map(formatRepoResult);
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "xgov-opensource-repo-scraper",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -9,11 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "bluebird": "^3.7.2",
         "commander": "^12.1.0",
-        "github": "^14.0.0",
-        "js-yaml": "^3.13.1",
-        "octokat": "^0.4.18"
+        "js-yaml": "^4.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -22,9 +19,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -64,15 +61,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -105,20 +102,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -127,13 +124,6 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
       "version": "14.0.0",
@@ -148,23 +138,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -265,9 +242,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -288,9 +265,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -321,12 +298,10 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -334,11 +309,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -402,6 +372,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -467,25 +438,25 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
-      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.1",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -504,7 +475,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -574,22 +545,10 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -698,17 +657,11 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/github": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-14.0.0.tgz",
-      "integrity": "sha512-34/VqwhYGeYN0VHBSH49TmRWMF7emy32qjK6POiW47T/QI2u/cpuKsmrWt7a218ew/73dF4dQSJE68/HXdNfPw==",
-      "deprecated": "'github' has been renamed to '@octokit/rest' (https://git.io/vNB11)"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -814,12 +767,12 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -894,9 +847,9 @@
       "license": "MIT"
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -919,28 +872,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/octokat": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/octokat/-/octokat-0.4.18.tgz",
-      "integrity": "sha1-r6flJlS1Rkkj+AGRezoxz/emhI0=",
-      "dependencies": {
-        "es6-promise": "3.0.2",
-        "xmlhttprequest": "~1.8.0"
-      }
-    },
-    "node_modules/octokat/node_modules/es6-promise": {
-      "version": "3.0.2",
-      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
-    },
-    "node_modules/octokat/node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -1078,11 +1009,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -1170,773 +1096,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    }
-  },
-  "dependencies": {
-    "@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "3.4.3",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-          "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-          "dev": true
-        }
-      }
-    },
-    "@eslint-community/regexpp": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
-      "dev": true
-    },
-    "@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
-      "dev": true,
-      "requires": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
-      }
-    },
-    "@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
-      "dev": true,
-      "requires": {
-        "@eslint/core": "^0.17.0"
-      }
-    },
-    "@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
-      "dev": true,
-      "requires": {
-        "@types/json-schema": "^7.0.15"
-      }
-    },
-    "@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "globals": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-          "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        }
-      }
-    },
-    "@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
-      "dev": true
-    },
-    "@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
-      "dev": true
-    },
-    "@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
-      "dev": true,
-      "requires": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      }
-    },
-    "@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true
-    },
-    "@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-      "dev": true,
-      "requires": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.4.0"
-      }
-    },
-    "@humanwhocodes/module-importer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true
-    },
-    "@humanwhocodes/retry": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "dev": true
-    },
-    "@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true
-    },
-    "@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
-    "acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true
-    },
-    "acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
-    "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
-    },
-    "chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
-    },
-    "debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "requires": {
-        "ms": "^2.1.3"
-      }
-    },
-    "deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
-    },
-    "eslint": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
-      "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
-      "dev": true,
-      "requires": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.1",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      }
-    },
-    "eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      }
-    },
-    "eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true
-    },
-    "espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^5.1.0"
-      }
-    },
-    "esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^5.2.0"
-      }
-    },
-    "estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
-    },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
-    },
-    "file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
-      "requires": {
-        "flat-cache": "^4.0.0"
-      }
-    },
-    "find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "requires": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      }
-    },
-    "flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
-      "requires": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      }
-    },
-    "flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true
-    },
-    "github": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/github/-/github-14.0.0.tgz",
-      "integrity": "sha512-34/VqwhYGeYN0VHBSH49TmRWMF7emy32qjK6POiW47T/QI2u/cpuKsmrWt7a218ew/73dF4dQSJE68/HXdNfPw=="
-    },
-    "glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "requires": {
-        "is-glob": "^4.0.3"
-      }
-    },
-    "globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
-      "dev": true
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
-    },
-    "ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true
-    },
-    "import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
-    },
-    "keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "requires": {
-        "json-buffer": "3.0.1"
-      }
-    },
-    "levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      }
-    },
-    "locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "requires": {
-        "p-locate": "^5.0.0"
-      }
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
-    "natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
-    },
-    "octokat": {
-      "version": "0.4.18",
-      "resolved": "https://registry.npmjs.org/octokat/-/octokat-0.4.18.tgz",
-      "integrity": "sha1-r6flJlS1Rkkj+AGRezoxz/emhI0=",
-      "requires": {
-        "es6-promise": "3.0.2",
-        "xmlhttprequest": "~1.8.0"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "3.0.2",
-          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
-        },
-        "xmlhttprequest": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-          "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
-        }
-      }
-    },
-    "optionator": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
-      "requires": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.5"
-      }
-    },
-    "p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "requires": {
-        "yocto-queue": "^0.1.0"
-      }
-    },
-    "p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "requires": {
-        "p-limit": "^3.0.2"
-      }
-    },
-    "parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "requires": {
-        "callsites": "^3.0.0"
-      }
-    },
-    "path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
-    },
-    "prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true
-    },
-    "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
-    },
-    "type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "^1.2.1"
-      }
-    },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true
-    },
-    "yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,11 +20,8 @@
   },
   "homepage": "https://github.com/UKHomeOffice/xgov-opensource-repo-scraper#readme",
   "dependencies": {
-    "bluebird": "^3.7.2",
     "commander": "^12.1.0",
-    "github": "^14.0.0",
-    "js-yaml": "^3.13.1",
-    "octokat": "^0.4.18"
+    "js-yaml": "^4.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",


### PR DESCRIPTION
## Summary

- **Replace REST with GraphQL API**: Batch 3 orgs per query instead of 1 repo per request. Remove deprecated deps (octokat, bluebird, github) — down from 5 to 2 deps (commander, js-yaml).
- **Fan-out/fan-in CI**: Split org list across 4 parallel matrix scrape jobs, merge results in a build step. Round-robin distribution spreads large orgs evenly.
- **Change detection cache**: Lightweight GraphQL query checks if orgs have changed before re-fetching. Cached nightly runs complete in ~1.5min.
- **CI optimizations**: `npm ci --omit=dev` for scrape jobs, `cache: 'npm'` in setup-node, inline merge (no npm install in build job).

### Performance

| Metric | Before | After (uncached) | After (cached) |
|--------|--------|-------------------|-----------------|
| Wall-clock | 8m | **~6m** | **~1.5m** |
| API approach | REST | GraphQL (batched) | GraphQL + cache |
| Dependencies | 5 | 2 | 2 |
| CI jobs | 1 sequential | 4 parallel + merge | same |

## Test plan

- [x] Verified uncached cold runs complete in ~6min (tested 5 configurations)
- [x] Verified cached runs complete in ~1.5min
- [x] Verified repo count matches (~25k repos from ~200 orgs)
- [x] ESLint passes
- [x] All CI jobs (test, scrape matrix, build, publish) succeed