### PR TITLE
feat: hourly SBOM collection workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,43 +82,6 @@ jobs:
           name: public.tar
           path: public.tar
 
-  sbom:
-    needs: build
-    if: github.ref == 'refs/heads/master'
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
-    steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/setup-node@v4.1.0
-        with:
-          node-version-file: '.nvm'
-          cache: 'npm'
-      - run: npm ci --omit=dev
-      - uses: actions/download-artifact@v4.1.8
-        with:
-          name: public.tar
-      - run: tar -xf public.tar
-      - name: Restore SBOM cache
-        uses: actions/cache@v4
-        with:
-          path: sbom-cache/
-          key: sbom-cache-${{ github.run_id }}
-          restore-keys: |
-            sbom-cache-
-      - name: Fetch SBOMs (incremental)
-        run: node index.js fetch-sboms --repos-file ./public/repos.json --cache-dir ./sbom-cache --budget 95 --max-hours 5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish SBOMs
-        run: node index.js publish-sboms --repos-file ./public/repos.json --cache-dir ./sbom-cache --output-dir ./public
-      - run: tar -cf public.tar ./public
-      - uses: actions/upload-artifact@v4.4.3
-        with:
-          name: public.tar
-          path: public.tar
-          overwrite: true
-
   publish:
     if: github.ref == 'refs/heads/master'
     permissions:
@@ -127,7 +90,6 @@ jobs:
       id-token: write
     needs:
       - build
-      - sbom
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,53 @@
+name: SBOM Collection
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment:
+      name: github-pages
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4.1.0
+        with:
+          node-version-file: '.nvm'
+          cache: 'npm'
+      - run: npm ci --omit=dev
+      - name: Download published repos.json
+        run: curl -sSf https://uk-x-gov-software-community.github.io/xgov-opensource-repo-scraper/repos.json -o repos.json
+      - name: Restore SBOM cache
+        uses: actions/cache@v4
+        with:
+          path: sbom-cache/
+          key: sbom-cache-${{ github.run_id }}
+          restore-keys: |
+            sbom-cache-
+      - name: Fetch SBOMs (incremental)
+        run: node index.js fetch-sboms --repos-file ./repos.json --cache-dir ./sbom-cache --budget 95 --max-hours 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build public directory
+        run: |
+          cp repos.json public/repos.json
+          node index.js publish-sboms --repos-file ./public/repos.json --cache-dir ./sbom-cache --output-dir ./public
+      - uses: actions/configure-pages@v5.0.0
+      - uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          path: public
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4.0.5

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import yaml from "js-yaml";
 import { writeFileSync, readFileSync, mkdirSync, existsSync } from "fs";
 import { join } from "path";
+import { gzipSync } from "zlib";
 import { Command } from "commander";
 
 const program = new Command();
@@ -701,11 +702,11 @@ program
           const destDir = join(sbomOutputDir, repo.owner);
           mkdirSync(destDir, { recursive: true });
           writeFileSync(
-            join(destDir, `${repo.name}.json`),
-            readFileSync(srcPath)
+            join(destDir, `${repo.name}.json.gz`),
+            gzipSync(readFileSync(srcPath))
           );
           copiedCount++;
-          repo.sbom = `sbom/${repo.owner}/${repo.name}.json`;
+          repo.sbom = `sbom/${repo.owner}/${repo.name}.json.gz`;
         }
       }
     }


### PR DESCRIPTION
## Summary
- Splits SBOM collection into its own hourly workflow (`sbom.yml`)
- Downloads `repos.json` from GitHub Pages — no need to re-scrape
- Shared `pages` concurrency group prevents deploy conflicts between Publisher and SBOM workflows
- Budget: 95 SBOMs/hour → full 26k repo coverage in ~12 days (vs ~276 days with nightly)

## Changes
- **`main.yml`**: Removed `sbom` job, `publish` now only depends on `build`
- **`sbom.yml`**: New workflow — hourly cron, fetches SBOMs incrementally, deploys to Pages

## Test plan
- [ ] PR CI: test, scrape, build jobs pass
- [ ] After merge: verify hourly SBOM workflow triggers and fetches 95 SBOMs
- [ ] Verify Pages deploy includes SBOM files and enriched repos.json