### PR TITLE
feat: add Datasette Lite explore links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Or you can navigate it via the [webpage](https://uk-x-gov-software-community.git
 Or you can import the json dynamically into your favourite tool.
 To demonstrate this I've created [a Google Sheet](https://docs.google.com/spreadsheets/d/1S4k63hpb2oLEUPva1N2iTNi-NsyRKLystYGKd6zuLII/edit?usp=sharing) for this
 <img width="1758" alt="image" src="https://user-images.githubusercontent.com/715120/194125329-9bb868d6-793f-4da7-81d6-8bc6c766fe7d.png">
+
+You can also [explore the data with Datasette Lite](https://lite.datasette.io/?json=https://www.uk-x-gov-software-community.org.uk/xgov-opensource-repo-scraper/repos.json#/data/repos) which loads the JSON into a SQLite database in your browser via WebAssembly, giving you full SQL querying, filtering, and export capabilities with no server required.

--- a/public/index.html
+++ b/public/index.html
@@ -449,6 +449,7 @@
       <a href="https://github.com/uk-x-gov-software-community/xgov-opensource-repo-scraper">Pull requests welcome</a>.
       The raw data is available as <a href="./repos.json">repos.json</a> for your own analysis — prefer linking to it rather than downloading a copy, so your tools always use the latest data.
       A consolidated <a href="./sbom.json">CycloneDX SBOM</a> (<a href="./sbom.json.gz">gzipped</a>) and individual <a href="./sbom/">SPDX SBOMs</a> are collected hourly via the GitHub dependency graph API.
+      You can also <a href="https://lite.datasette.io/?json=https://www.uk-x-gov-software-community.org.uk/xgov-opensource-repo-scraper/repos.json#/data/repos">explore the data with Datasette Lite</a> for SQL-powered querying directly in your browser.
     </p>
   </header>
 


### PR DESCRIPTION
## Summary
- Adds links to [Datasette Lite](https://lite.datasette.io/) in both `index.html` and `README.md` so users can explore the repos.json data with full SQL querying in the browser
- Uses the custom domain URL (`www.uk-x-gov-software-community.org.uk`) rather than `github.io` because the github.io → custom domain 301 redirect does not include CORS headers, causing Pyodide's `pyfetch` to fail with `AbortError: Failed to fetch`

## Test plan
- [ ] Verify the [Datasette Lite link](https://lite.datasette.io/?json=https://www.uk-x-gov-software-community.org.uk/xgov-opensource-repo-scraper/repos.json#/data/repos) loads successfully
- [ ] Check the link renders correctly in the index.html header
- [ ] Check the link renders correctly in the README