### PR TITLE
feat: add isFork field to scraped data

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,6 +101,7 @@ function buildRepoQuery(entries) {
           description
           url
           isArchived
+          isFork
           licenseInfo { key name spdxId }
           stargazerCount
           primaryLanguage { name }
@@ -137,6 +138,7 @@ function formatRepo(node) {
     description: node.description,
     url: node.url,
     archived: node.isArchived,
+    isFork: node.isFork,
     license: node.licenseInfo,
     stargazersCount: node.stargazerCount,
     language: node.primaryLanguage?.name ?? null,


### PR DESCRIPTION
For one project idea, it'd be handy to be able to filter out repos that are forks of other repos. Tiny PR to add the isFork field to the scraped data.

I figured the web dashboard has enough columns already, but happy to add it there too if desired.

Manual testing conducted locally:

1. Ran `npm start get-repos GSTT-CSC -- --write repos.json` and eye-balled that isFork had true and false values, and that the true was correct. [repos.json](https://github.com/user-attachments/files/26195178/repos.json) for the output. 

Cheers!