### PR TITLE
SBOM pipeline: classify version-resolution + dev/runtime scope at publish time

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import { writeFileSync, readFileSync, mkdirSync, existsSync, copyFileSync } from
 import { join } from "path";
 import { gzipSync } from "zlib";
 import { Command } from "commander";
+import { classifyRepo, emptyCounts, addCounts } from "./sbom-normalize.js";
 
 const program = new Command();
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
@@ -959,8 +960,23 @@ program
     writeFileSync(options.reposFile, JSON.stringify(repos, null, 2));
     mkdirSync(sbomOutputDir, { recursive: true });
 
-    // Build consolidated CycloneDX SBOM
+    // Build consolidated CycloneDX SBOM.
+    //
+    // Every package is classified at publish time (see sbom-normalize.js) so the
+    // upstream GitHub SBOM's two blind spots stop poisoning CVE scans: packages
+    // with no resolved version and dev/build/CI tooling are marked CycloneDX
+    // `scope: "excluded"` with an auditable `xgov:scope-basis` property, while
+    // version-pinned runtime dependencies stay `scope: "required"`.
+    //   * sbom.json          — full inventory, now scope/resolution annotated.
+    //   * sbom-runtime.json   — required-scope, version-pinned components only:
+    //                           the artifact to point a scanner at (no phantom
+    //                           name-only hits, no build-tool noise).
+    //   * sbom-quality.json   — per-repo + estate resolution/scope metrics so the
+    //                           coverage gap is measurable, not hidden.
     const cdxComponents = [];
+    const runtimeComponents = [];
+    const qualityPerRepo = [];
+    const qualityTotals = emptyCounts();
     for (const repo of repos) {
       if (!repo.sbom) continue;
       const srcPath = join(cacheDir, "spdx", repo.owner, `${repo.name}.json`);
@@ -969,21 +985,18 @@ program
         const spdx = JSON.parse(readFileSync(srcPath, "utf8"));
         // Tolerate both bare SPDX (new async API) and the legacy { sbom: {...} } wrapper
         const packages = spdx.packages || spdx.sbom?.packages || [];
-        const deps = packages.map((pkg) => {
-          const purl = pkg.externalRefs?.find(
-            (r) => r.referenceType === "purl"
-          )?.referenceLocator;
-          return {
-            type: "library",
-            name: pkg.name,
-            version: pkg.versionInfo || undefined,
-            purl: purl || undefined,
-            licenses: pkg.licenseConcluded && pkg.licenseConcluded !== "NOASSERTION"
-              ? [{ license: { id: pkg.licenseConcluded } }]
-              : undefined,
-          };
+        const { components, counts } = classifyRepo(packages);
+        // Re-attach license info (classifyRepo is version/scope-only) by position.
+        components.forEach((c, i) => {
+          const lic = packages[i]?.licenseConcluded;
+          if (lic && lic !== "NOASSERTION") {
+            c.licenses = [{ license: { id: lic } }];
+          }
         });
-        cdxComponents.push({
+        addCounts(qualityTotals, counts);
+        qualityPerRepo.push({ repo: `${repo.owner}/${repo.name}`, ...counts });
+
+        const appMeta = {
           type: "application",
           name: `${repo.owner}/${repo.name}`,
           version: "",
@@ -991,35 +1004,79 @@ program
           externalReferences: [
             { type: "vcs", url: repo.url || `https://github.com/${repo.owner}/${repo.name}` },
           ],
-          components: deps.length > 0 ? deps : undefined,
+        };
+        cdxComponents.push({
+          ...appMeta,
+          components: components.length > 0 ? components : undefined,
         });
+        const runtime = components.filter((c) => c.scope === "required");
+        if (runtime.length > 0) {
+          runtimeComponents.push({ ...appMeta, components: runtime });
+        }
       } catch {
         // Skip corrupt SPDX files
       }
     }
 
-    const cdx = {
+    const cdxMeta = (name, description) => ({
+      timestamp: new Date().toISOString(),
+      component: { type: "application", name, description },
+      tools: [{ name: "xgov-opensource-repo-scraper" }],
+    });
+    const cdxDoc = (metadata, components) => ({
       bomFormat: "CycloneDX",
       specVersion: "1.5",
       version: 1,
-      metadata: {
-        timestamp: new Date().toISOString(),
-        component: {
-          type: "application",
-          name: "uk-gov-open-source",
-          description: "Consolidated SBOM for UK government open source repositories",
-        },
-        tools: [{ name: "xgov-opensource-repo-scraper" }],
-      },
-      components: cdxComponents,
-    };
+      metadata,
+      components,
+    });
 
+    const cdx = cdxDoc(
+      cdxMeta(
+        "uk-gov-open-source",
+        "Consolidated SBOM for UK government open source repositories"
+      ),
+      cdxComponents
+    );
     const cdxJson = JSON.stringify(cdx);
     const cdxGz = gzipSync(cdxJson);
     writeFileSync(join(outputDir, "sbom.json"), cdxJson);
     writeFileSync(join(outputDir, "sbom.json.gz"), cdxGz);
     console.log(
       `Published consolidated CycloneDX SBOM: ${cdxComponents.length} repos (${(cdxJson.length / 1024 / 1024).toFixed(1)}MB, ${(cdxGz.length / 1024 / 1024).toFixed(1)}MB gzipped)`
+    );
+
+    const runtimeCdx = cdxDoc(
+      cdxMeta(
+        "uk-gov-open-source-runtime",
+        "Runtime-only (version-pinned, scope=required) consolidated SBOM for CVE scanning — excludes dev/build/CI tooling and version-unresolved packages"
+      ),
+      runtimeComponents
+    );
+    const runtimeJson = JSON.stringify(runtimeCdx);
+    writeFileSync(join(outputDir, "sbom-runtime.json"), runtimeJson);
+    writeFileSync(join(outputDir, "sbom-runtime.json.gz"), gzipSync(runtimeJson));
+    console.log(
+      `Published runtime-only SBOM: ${runtimeComponents.length} repos, ${qualityTotals.runtime} scannable components (excluded ${qualityTotals.excludedUnresolved} unresolved, ${qualityTotals.excludedDev} dev-tooling, ${qualityTotals.excludedCi} CI-action)`
+    );
+
+    const pct = (n) =>
+      qualityTotals.packages > 0
+        ? Math.round((n / qualityTotals.packages) * 1000) / 10
+        : 0;
+    const quality = {
+      generatedAt: new Date().toISOString(),
+      totals: qualityTotals,
+      resolvedPct: pct(qualityTotals.resolved),
+      runtimePct: pct(qualityTotals.runtime),
+      perRepo: qualityPerRepo,
+    };
+    writeFileSync(
+      join(outputDir, "sbom-quality.json"),
+      JSON.stringify(quality, null, 2)
+    );
+    console.log(
+      `SBOM quality: ${qualityTotals.packages} packages, ${qualityTotals.resolved} resolved (${quality.resolvedPct}%), ${qualityTotals.unresolved} unresolved`
     );
 
     console.log(

--- a/sbom-normalize.js
+++ b/sbom-normalize.js
@@ -1,0 +1,241 @@
+// ---------- SBOM normalisation ----------
+//
+// GitHub's dependency-graph SBOM API is the upstream source for every SBOM we
+// publish. It emits a *flat* SPDX package list whose only relationships are
+// DESCRIBES and DEPENDS_ON — it carries **no dev/runtime scope** and, for
+// manifests without a committed lockfile (most Maven/Gradle/Go projects), it
+// emits packages with **no resolved version** (versionInfo absent / NOASSERTION).
+//
+// Both gaps poison downstream CVE scanning:
+//   * A version-less package can only be matched by *name*, which is how the
+//     consolidated SBOM produced phantom hits (e.g. a Spring4Shell "match" on a
+//     spring-boot-starter-web entry that had no version at all).
+//   * Build/test tooling (eslint, webpack, junit, pytest, CI actions, …) is
+//     emitted alongside deployed runtime dependencies with nothing to tell them
+//     apart, inflating the apparent attack surface with code that never ships.
+//
+// This module classifies every package at publish time so the consolidated
+// CycloneDX can carry a standards-compliant `scope` (required | excluded) plus
+// auditable `properties`, and a version-pinned runtime-only artifact can be
+// emitted for scanners. We cannot invent versions GitHub never resolved, but we
+// can stop them masquerading as scannable facts.
+
+// Concrete, pinned version? Reject empties, NOASSERTION and unpinned ranges
+// (Maven `[1.0,2.0)`, npm `^1.2.0`, etc.) — only a single fixed version can be
+// reliably CVE-matched.
+export function isResolvedVersion(version) {
+  if (!version || typeof version !== "string") return false;
+  const v = version.trim();
+  if (v === "" || v.toUpperCase() === "NOASSERTION") return false;
+  if (/[\s,|[\]()*^~<>=]/.test(v)) return false; // range / constraint, not a pin
+  return /\d/.test(v); // must contain at least one digit
+}
+
+// purls encode the ecosystem (`pkg:<type>/…`) and frequently the pinned version
+// (`…@<version>`) even when SPDX versionInfo is missing — recover both.
+export function parsePurl(purl) {
+  if (!purl || typeof purl !== "string") return { type: null, version: null };
+  const m = /^pkg:([^/]+)\//.exec(purl);
+  const type = m ? m[1].toLowerCase() : null;
+  const at = purl.lastIndexOf("@");
+  let version = null;
+  if (at > 4) {
+    const tail = purl.slice(at + 1);
+    // Stop at any qualifier/subpath that follows the version.
+    version = decodeURIComponent(tail.split(/[?#]/)[0]);
+  }
+  return { type, version };
+}
+
+// Conservative dev/build/test tooling matchers, keyed by purl ecosystem. These
+// are dependencies that exist to *build or test* a project, not to run the
+// deployed service — so they are out of the production attack surface. Kept
+// deliberately tight (well-known names only) to avoid excluding real runtime
+// code; anything unrecognised stays in scope.
+const DEV_RULES = {
+  npm: [
+    /^@types\//,
+    /^@babel\//,
+    /^@storybook\//,
+    /^@testing-library\//,
+    /^@playwright\//,
+    /^eslint/,
+    /^prettier$/,
+    /^stylelint/,
+    /^typescript$/,
+    /^ts-node$/,
+    /^tsx$/,
+    /^nodemon$/,
+    /^concurrently$/,
+    /^rimraf$/,
+    /^husky$/,
+    /^lint-staged$/,
+    /^(jest|mocha|chai|jasmine|karma|vitest|cypress|playwright|sinon|nock|supertest|enzyme|nyc)$/,
+    /^(webpack|rollup|vite|gulp|grunt|parcel|esbuild|browserify)/,
+    /^(sass|node-sass|less|postcss|autoprefixer)$/,
+    /^@faker-js\/faker$/,
+    /^faker$/,
+  ],
+  maven: [
+    /^junit:/,
+    /^org\.junit/,
+    /^org\.mockito:/,
+    /^org\.assertj:/,
+    /^org\.hamcrest:/,
+    /^org\.testng:/,
+    /^org\.testcontainers:/,
+    /^org\.seleniumhq/,
+    /^com\.github\.tomakehurst:wiremock/,
+    /spring-boot-starter-test/,
+    /-maven-plugin/,
+    /-gradle-plugin/,
+  ],
+  gem: [
+    /^(rspec|rspec-core|rspec-rails|rubocop|brakeman|capybara|pry|byebug|simplecov|webmock|vcr|database_cleaner|factory_bot|factory_bot_rails|web-console|spring|listen|guard)/,
+  ],
+  pypi: [
+    /^(pytest|tox|nox|flake8|black|isort|mypy|pylint|bandit|pre-commit|coverage|mock|factory-boy|faker|nose|sphinx)$/,
+    /^pytest-/,
+  ],
+  nuget: [
+    /^(xunit|nunit|moq|fluentassertions|coverlet|shouldly|specflow|stylecop)/i,
+    /\.tests?$/i,
+    /^microsoft\.net\.test\.sdk$/i,
+  ],
+  composer: [
+    /^phpunit\/phpunit$/,
+    /^squizlabs\/php_codesniffer$/,
+    /^friendsofphp\/php-cs-fixer$/,
+    /^phpstan\/phpstan$/,
+    /^mockery\/mockery$/,
+    /^fakerphp\/faker$/,
+    /^nunomaduro\/collision$/,
+    /^laravel\/(sail|pint)$/,
+    /^barryvdh\/laravel-debugbar$/,
+  ],
+};
+
+// Ecosystems whose packages are never part of a deployed service's runtime.
+const NON_RUNTIME_ECOSYSTEMS = new Set(["githubactions", "actions"]);
+
+// Recover a Maven `group:artifact` coordinate from a purl
+// (`pkg:maven/<group>/<artifact>@<version>` → `<group>:<artifact>`).
+function mavenCoordinate(purl) {
+  const m = /^pkg:maven\/([^@?#]+)/i.exec(purl || "");
+  if (!m) return null;
+  return m[1].replace("/", ":");
+}
+
+function matchesDevRule(ecosystem, name, purl) {
+  const rules = DEV_RULES[ecosystem];
+  if (!rules) return false;
+  // Maven matchers run against the `group:artifact` coordinate; others against
+  // the bare package name.
+  const subject =
+    ecosystem === "maven"
+      ? mavenCoordinate(purl) || name || ""
+      : name || "";
+  return rules.some((re) => re.test(subject));
+}
+
+// Classify a single SPDX package. Returns the backfilled version plus a
+// CycloneDX `scope` (required → scan it; excluded → out of the runtime attack
+// surface) and the human-readable `basis` for the decision.
+export function classifyPackage(pkg) {
+  const purl = pkg.externalRefs?.find((r) => r.referenceType === "purl")
+    ?.referenceLocator;
+  const parsed = parsePurl(purl);
+  const ecosystem = parsed.type;
+
+  // Prefer SPDX versionInfo; fall back to the version embedded in the purl.
+  let version = pkg.versionInfo;
+  if (!isResolvedVersion(version) && isResolvedVersion(parsed.version)) {
+    version = parsed.version;
+  }
+  const resolved = isResolvedVersion(version);
+
+  let scope = "required";
+  let basis = "runtime";
+  if (ecosystem && NON_RUNTIME_ECOSYSTEMS.has(ecosystem)) {
+    scope = "excluded";
+    basis = "ci-action";
+  } else if (matchesDevRule(ecosystem, pkg.name, purl)) {
+    scope = "excluded";
+    basis = "dev-tooling";
+  } else if (!resolved) {
+    // Name-only package: cannot be version-matched, so excluding it is what
+    // stops the phantom CVE hits — but we record it so the gap stays visible.
+    scope = "excluded";
+    basis = "unresolved-version";
+  }
+
+  return {
+    name: pkg.name,
+    version: resolved ? version : undefined,
+    purl: purl || undefined,
+    ecosystem,
+    resolved,
+    scope,
+    basis,
+  };
+}
+
+// Roll a repo's classified packages into a CycloneDX component carrying the
+// scope + auditable properties, alongside per-repo quality counters.
+export function classifyRepo(packages) {
+  const components = [];
+  const counts = {
+    packages: 0,
+    resolved: 0,
+    unresolved: 0,
+    runtime: 0,
+    excludedDev: 0,
+    excludedUnresolved: 0,
+    excludedCi: 0,
+  };
+
+  for (const pkg of packages) {
+    const c = classifyPackage(pkg);
+    counts.packages++;
+    if (c.resolved) counts.resolved++;
+    else counts.unresolved++;
+    if (c.scope === "required") counts.runtime++;
+    else if (c.basis === "dev-tooling") counts.excludedDev++;
+    else if (c.basis === "unresolved-version") counts.excludedUnresolved++;
+    else if (c.basis === "ci-action") counts.excludedCi++;
+
+    components.push({
+      type: "library",
+      name: c.name,
+      version: c.version,
+      purl: c.purl,
+      scope: c.scope,
+      properties: [
+        { name: "xgov:resolution", value: c.resolved ? "resolved" : "unresolved" },
+        { name: "xgov:scope-basis", value: c.basis },
+      ],
+    });
+  }
+
+  return { components, counts };
+}
+
+// Sum per-repo counters into an estate-wide total.
+export function emptyCounts() {
+  return {
+    packages: 0,
+    resolved: 0,
+    unresolved: 0,
+    runtime: 0,
+    excludedDev: 0,
+    excludedUnresolved: 0,
+    excludedCi: 0,
+  };
+}
+
+export function addCounts(total, counts) {
+  for (const k of Object.keys(counts)) {
+    total[k] = (total[k] || 0) + counts[k];
+  }
+  return total;
+}


### PR DESCRIPTION
## Problem

GitHub's dependency-graph SBOM API is the upstream source for every SBOM we publish. It emits a **flat** SPDX package list whose only relationships are `DESCRIBES`/`DEPENDS_ON` — so it carries **no dev/runtime scope**, and for manifests without a committed lockfile (most Maven/Gradle/Go projects) it emits packages with **no resolved version**.

Both gaps poison the consolidated CycloneDX (`sbom.json`) used for estate-wide CVE scanning:

- A **version-less** package can only be matched by *name*, which produces phantom CVE hits — e.g. a Spring4Shell-style "match" on a `spring-boot-starter-web` entry that has no version at all.
- **Build/test/CI tooling** (eslint, webpack, junit, pytest, GitHub Actions, …) is published alongside deployed runtime dependencies with nothing to tell them apart, inflating the apparent attack surface with code that never ships.

## Change

New pure module `sbom-normalize.js` classifies every package at publish time:

- **Recovers the version from the purl** (`…@<version>`) when SPDX `versionInfo` is missing.
- **Flags unresolved** versions (empty / `NOASSERTION` / ranges like `^1.2.0`, `[1.0,2.0)`).
- **Tags dev/build/CI tooling** per ecosystem (npm, maven, gem, pypi, nuget, composer, githubactions) with conservative, well-known-name-only matchers.

`publish-sboms` now emits:

| Artifact | Purpose |
|---|---|
| `sbom.json` | Full inventory (unchanged consumers still work), now with CycloneDX `scope` (`required`/`excluded`) + auditable `xgov:resolution` / `xgov:scope-basis` properties on every component |
| `sbom-runtime.json` (+ `.gz`) | **New** — version-pinned, `scope: required` components only: the artifact to point a scanner at (no phantom name-only hits, no build-tool noise) |
| `sbom-quality.json` | **New** — per-repo + estate resolution/scope metrics, so the coverage gap is measurable over time |

We cannot invent versions GitHub never resolved — but we stop them masquerading as scannable facts. Per-repo published SPDX files are left canonical/untouched; only the consolidated CycloneDX is enriched.

## Verification

- ESLint clean on both changed files; 13/13 classifier unit assertions pass.
- End-to-end `publish-sboms` on real cached SPDX (10 repos, 170 packages): 99 scannable runtime components; 71 demoted (37 version-unresolved, 29 dev-tooling, 5 CI-action). Resolution rate 70.6%.
- **grype A/B on the consolidated SBOMs**: Crit/High drops **6 → 4**. The *only* dropped match is `org.springframework.boot:spring-boot-starter-web@` (empty version) for `GHSA-36p3-wjmg-h94x` — the exact name-match false-positive class. All four version-pinned runtime matches (`commons-text@1.9` / Text4Shell, `postgresql@42.7.7`, `spring-boot@3.5.3`, `commons-io@2.11.0`) are retained.

The hourly `sbom.yml` workflow runs `publish-sboms` unchanged, so it picks this up automatically — no CI edit needed.

https://claude.ai/code/session_01QomK2q9PwnRz4UMXVTkc7j
