### PR TITLE
fix(get-orgs): point UK departments fetch at upstream gh-pages branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function getOrgs() {
   const allDepartments = yamlLoad(
     await (
       await fetch(
-        "https://raw.githubusercontent.com/chrisns/government.github.com/add-uk-public-sector-orgs-202602/_data/governments.yml"
+        "https://raw.githubusercontent.com/github/government.github.com/gh-pages/_data/governments.yml"
       )
     ).text()
   );


### PR DESCRIPTION
## Summary
- The org list command fails. It reads UK department and council data from a branch on a fork (`chrisns/government.github.com`, branch `add-uk-public-sector-orgs-202602`). GitHub now returns 404 for that branch.
- The UK data from that branch is merged into the upstream repository. It is on the `github/government.github.com` repo's `gh-pages` branch now.
- This change updates the fetch URL in `getOrgs()` to read `governments.yml` from the upstream `gh-pages` branch.

## Test plan
- [x] Ran `node index.js get-orgs` and confirmed it returns 223 orgs (46 UK Councils + 166 UK Central + 11 UK Research), with no fetch errors.
- [x] Ran `npm run lint`. The only warning is pre-existing and unrelated to this change.